### PR TITLE
Update test configs to allow empty suites

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -7,7 +7,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "build": "expo export",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "lint": "eslint . --max-warnings=0"
   },
   "dependencies": {

--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.(ts|js)'],

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsc && node dist/index.js",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "lint": "eslint . --max-warnings=0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- switch to ESM export in server Jest config
- allow tests with no files for server and mobile

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684252f1e8c48324ba4046e4812aa4e4