### PR TITLE
Fix mood history pagination bug

### DIFF
--- a/packages/server/__tests__/moods.test.ts
+++ b/packages/server/__tests__/moods.test.ts
@@ -1,0 +1,14 @@
+import request from 'supertest';
+import { createApp } from '../src/index';
+
+describe('GET /api/moods', () => {
+  it('should respect limit and offset query parameters even when zero', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/moods?limit=0&offset=0');
+    expect(res.status).toBe(200);
+    expect(res.body.limit).toBe(0);
+    expect(res.body.offset).toBe(0);
+    expect(Array.isArray(res.body.moods)).toBe(true);
+    expect(res.body.moods.length).toBe(0);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -325,8 +325,10 @@ function createApp(): Application {
   
   // Retrieve mood history endpoint
   app.get('/api/moods', (req: Request, res: Response) => {
-    const limit = parseInt(req.query.limit as string) || 50;
-    const offset = parseInt(req.query.offset as string) || 0;
+    const limitParam = parseInt(req.query.limit as string, 10);
+    const offsetParam = parseInt(req.query.offset as string, 10);
+    const limit = Number.isNaN(limitParam) ? 50 : limitParam;
+    const offset = Number.isNaN(offsetParam) ? 0 : offsetParam;
     
     const paginatedEntries = moodEntries
       .slice()


### PR DESCRIPTION
## Summary
- fix `limit` & `offset` parsing so zero is respected
- add regression test for `/api/moods` query params

## Testing
- `npx jest packages/server/__tests__/moods.test.ts --runInBand` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424e90a58c83249b0685bac1a61f8f