### PR TITLE
Add guard for direct execution of server entrypoint

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,8 +3,22 @@ import { pipeline } from "@xenova/transformers";
 import { resolve } from "path";
 import { fileURLToPath } from "url";
 
-// ES module equivalents for __filename and __dirname
-const __filename = fileURLToPath(import.meta.url);
+// Resolve the current module filename in both ESM and CJS environments without
+// triggering syntax errors when the code is transpiled to CommonJS for tests.
+const importMetaUrl = (() => {
+  try {
+    return eval("import.meta.url") as string;
+  } catch {
+    return undefined;
+  }
+})();
+
+const moduleFilename =
+  typeof __filename !== "undefined"
+    ? __filename
+    : importMetaUrl
+    ? fileURLToPath(importMetaUrl)
+    : undefined;
 
 /**
  * Type definitions for the application
@@ -490,7 +504,7 @@ export { createApp, startServer };
 
 const entrypoint = process.argv[1] ? resolve(process.argv[1]) : null;
 
-if (entrypoint && entrypoint === __filename) {
+if (entrypoint && moduleFilename && entrypoint === moduleFilename) {
   startServer().catch((error) => {
     console.error("Unhandled error while starting server:", error);
     process.exit(1);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,8 +1,10 @@
 import express, { Request, Response, NextFunction, Application } from "express";
 import { pipeline } from "@xenova/transformers";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
 
 // ES module equivalents for __filename and __dirname
-// const __filename = fileURLToPath(import.meta.url); // Commented out as it's not currently used
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * Type definitions for the application
@@ -485,3 +487,12 @@ async function startServer(): Promise<void> {
 }
 
 export { createApp, startServer };
+
+const entrypoint = process.argv[1] ? resolve(process.argv[1]) : null;
+
+if (entrypoint && entrypoint === __filename) {
+  startServer().catch((error) => {
+    console.error("Unhandled error while starting server:", error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- recreate the ESM `__filename` within the server entrypoint
- add a direct-execution guard that starts the server when the module is run directly
- preserve the ability to import `createApp` without side effects

## Testing
- pnpm --filter server build
- pnpm --filter server start *(fails: sentiment model download ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68e38390848c8324a700226870e11c2e