### PR TITLE
Sanitize server rate limit environment overrides

### DIFF
--- a/packages/server/__tests__/rate-limit.test.ts
+++ b/packages/server/__tests__/rate-limit.test.ts
@@ -1,0 +1,72 @@
+import request from "supertest";
+import { jest } from "@jest/globals";
+
+jest.mock("@xenova/transformers", () => ({
+  pipeline: jest.fn(() => async () => []),
+}));
+
+const ORIGINAL_ENV = process.env;
+
+async function loadCreateApp() {
+  let module: typeof import("../src/index") | undefined;
+  await jest.isolateModulesAsync(async () => {
+    module = await import("../src/index");
+  });
+  if (!module) {
+    throw new Error("Failed to load server module");
+  }
+  return module.createApp;
+}
+
+describe("rate limiting configuration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it("respects valid overrides", async () => {
+    process.env.RATE_LIMIT_MAX = "2";
+    process.env.RATE_LIMIT_WINDOW = "1000";
+
+    const createApp = await loadCreateApp();
+    const app = createApp();
+
+    const first = await request(app).get("/api/health");
+    expect(first.status).toBe(200);
+
+    const second = await request(app).get("/api/health");
+    expect(second.status).toBe(200);
+
+    const blocked = await request(app).get("/api/health");
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.message).toContain("Limit: 2 requests per 1 seconds");
+  });
+
+  it("falls back to defaults and warns on invalid overrides", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    process.env.RATE_LIMIT_MAX = "0";
+    process.env.RATE_LIMIT_WINDOW = "not-a-number";
+
+    const createApp = await loadCreateApp();
+    const app = createApp();
+
+    for (let i = 0; i < 100; i++) {
+      const response = await request(app).get("/api/health");
+      expect(response.status).toBe(200);
+    }
+
+    const blocked = await request(app).get("/api/health");
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.message).toContain("Limit: 100 requests per 900 seconds");
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0][0]).toContain("RATE_LIMIT_WINDOW");
+    expect(warnSpy.mock.calls[1][0]).toContain("RATE_LIMIT_MAX");
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -50,12 +50,50 @@ interface ErrorResponse {
 /**
  * Environment configuration
  */
+const DEFAULT_RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes in milliseconds
+const DEFAULT_RATE_LIMIT_MAX = 100; // 100 requests per window
+
+function sanitizeRateLimitValue(
+  value: string | undefined,
+  defaultValue: number,
+  envVar: "RATE_LIMIT_WINDOW" | "RATE_LIMIT_MAX",
+): number {
+  if (typeof value === "undefined") {
+    return defaultValue;
+  }
+
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    console.warn(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        warning: "Invalid rate limit configuration",
+        variable: envVar,
+        providedValue: value,
+        defaultApplied: defaultValue,
+      }),
+    );
+    return defaultValue;
+  }
+
+  return parsedValue;
+}
+
 const config = {
   port: process.env.PORT || 3000,
   nodeEnv: process.env.NODE_ENV || "development",
   corsOrigin: process.env.CORS_ORIGIN || "*",
-  rateLimitWindow: parseInt(process.env.RATE_LIMIT_WINDOW || "900000"), // 15 minutes
-  rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX || "100"), // 100 requests per window
+  rateLimitWindow: sanitizeRateLimitValue(
+    process.env.RATE_LIMIT_WINDOW,
+    DEFAULT_RATE_LIMIT_WINDOW,
+    "RATE_LIMIT_WINDOW",
+  ),
+  rateLimitMax: sanitizeRateLimitValue(
+    process.env.RATE_LIMIT_MAX,
+    DEFAULT_RATE_LIMIT_MAX,
+    "RATE_LIMIT_MAX",
+  ),
 };
 
 /**


### PR DESCRIPTION
## Summary
- sanitize rate limit environment overrides before initializing the server config
- emit a structured warning when invalid rate limit overrides are provided
- add tests verifying valid and invalid rate limit environments enforce caps and warn appropriately

## Testing
- pnpm --filter server test

------
https://chatgpt.com/codex/tasks/task_e_68e3881e63208324a8473691eee6a8d9